### PR TITLE
Make it possible to build for macOS

### DIFF
--- a/cpu-miner.c
+++ b/cpu-miner.c
@@ -78,19 +78,12 @@ static inline void affine_to_cpu(int id, int cpu)
 	cpuset_setaffinity(CPU_LEVEL_WHICH, CPU_WHICH_TID, -1, sizeof(cpuset_t), &set);
 }
 #else
-#include <pthread.h>
 static inline void drop_policy(void)
 {
 }
 
 static inline void affine_to_cpu(int id, int cpu)
 {
-	 cpu_set_t set;
-	 CPU_ZERO(&set);
-	 CPU_SET(cpu, &set);
-
-	 pthread_t thr = pthread_self();
-	 pthread_setaffinity_np(thr, sizeof(cpu_set_t), &set);
 }
 #endif
 


### PR DESCRIPTION
https://bitzeny.info/d/103-cpuminer/37:

```bash
./autogen.sh
./nomacro.pl
./configure CFLAGS="-O3 -march=native -funroll-loops -fomit-frame-pointer"
make
```

```bash
/Applications/Xcode.app/Contents/Developer/usr/bin/make  all-recursive
Making all in compat
make[3]: Nothing to be done for `all-am'.
gcc -DHAVE_CONFIG_H -I.  -I/usr/local/Cellar/curl/7.57.0/include  -pthread -I/usr/local/opt/openssl/include -fno-strict-aliasing -O3 -march=native -funroll-loops -fomit-frame-pointer -MT minerd-cpu-miner.o -MD -MP -MF .deps/minerd-cpu-miner.Tpo -c -o minerd-cpu-miner.o `test -f 'cpu-miner.c' || echo './'`cpu-miner.c
cpu-miner.c:88:3: error: use of undeclared identifier 'cpu_set_t'
         cpu_set_t set;
         ^
cpu-miner.c:89:3: warning: implicit declaration of function 'CPU_ZERO' is invalid in C99
      [-Wimplicit-function-declaration]
         CPU_ZERO(&set);
         ^
cpu-miner.c:89:13: error: use of undeclared identifier 'set'
         CPU_ZERO(&set);
                   ^
cpu-miner.c:90:3: warning: implicit declaration of function 'CPU_SET' is invalid in C99
      [-Wimplicit-function-declaration]
         CPU_SET(cpu, &set);
         ^
cpu-miner.c:90:17: error: use of undeclared identifier 'set'
         CPU_SET(cpu, &set);
                       ^
cpu-miner.c:93:3: warning: implicit declaration of function 'pthread_setaffinity_np' is invalid in C99
      [-Wimplicit-function-declaration]
         pthread_setaffinity_np(thr, sizeof(cpu_set_t), &set);
         ^
cpu-miner.c:93:38: error: use of undeclared identifier 'cpu_set_t'
         pthread_setaffinity_np(thr, sizeof(cpu_set_t), &set);
                                            ^
cpu-miner.c:93:51: error: use of undeclared identifier 'set'
         pthread_setaffinity_np(thr, sizeof(cpu_set_t), &set);
                                                         ^
3 warnings and 5 errors generated.
make[2]: *** [minerd-cpu-miner.o] Error 1
make[1]: *** [all-recursive] Error 1
make: *** [all] Error 2
```